### PR TITLE
Removes horse data on death

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.shantek</groupId>
     <artifactId>HorseGuard</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1</version>
     <packaging>jar</packaging>
 
     <name>HorseGuard</name>

--- a/src/main/java/io/shantek/Listeners.java
+++ b/src/main/java/io/shantek/Listeners.java
@@ -13,6 +13,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityTameEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
+import org.bukkit.event.entity.EntityDeathEvent;
 
 import java.util.HashSet;
 import java.util.UUID;
@@ -82,8 +83,6 @@ public class Listeners implements Listener {
         }
     }
 
-
-
     @EventHandler
     public void onEntityDamage(EntityDamageByEntityEvent event) {
         if (event.getEntity() instanceof AbstractHorse entity && event.getDamager() instanceof Player player) {
@@ -103,6 +102,16 @@ public class Listeners implements Listener {
             }
         }
     }
+    
+    // Event handler for horse death event. When a horse dies, remove it from the database.
+    @EventHandler
+    public void onEntityDeath(EntityDeathEvent event) {
+        if (event.getEntity() instanceof AbstractHorse entity) {
+            UUID entityUUID = entity.getUniqueId();
+            helperFunctions.removeHorse(entityUUID);
+        }
+    }
+
 
     private void claimEntity(Player player, LivingEntity entity, UUID entityUUID) {
         UUID playerUUID = player.getUniqueId();

--- a/src/main/java/io/shantek/functions/HelperFunctions.java
+++ b/src/main/java/io/shantek/functions/HelperFunctions.java
@@ -106,4 +106,10 @@ public class HelperFunctions {
         horseGuard.getConfiguration().saveHorseData(); // Save data after modifying
     }
 
+    public void removeHorse(UUID horseUUID) {
+        horseGuard.horseOwners.remove(horseUUID);
+        horseGuard.trustedPlayers.remove(horseUUID);
+        horseGuard.getConfiguration().saveHorseData(); // Save data after modifying
+    }
+
 }


### PR DESCRIPTION
- Adds a helper function `removeHorse` which removes a horse by UUID from the data file.
- Adds an event listener `onEntityDeath` for `AbstractHorse` and calls `removeHorse` for that UUID, then saves the data
- Bumps version number

Closes #4 