### PR TITLE
1.1.2 - Implement Disabled Worlds Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Players with this permission will be able to ride and lead any horse, ignoring a
 ### shantek.horseguard.damage
 Players with this permission will be able to harm any horse, ignoring any ownership or trust settings.
 
+### shantek.horseguard.reload
+Players with this permission will be able to reload the plugin configuration values.
+
 ![Plugin Usage Stats](https://bstats.org/signatures/bukkit/Horse%20Guard.svg)
 
 ## External Links

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.shantek</groupId>
     <artifactId>HorseGuard</artifactId>
-    <version>1.1.1</version>
+    <version>1.1.2</version>
     <packaging>jar</packaging>
 
     <name>HorseGuard</name>

--- a/src/main/java/io/shantek/Configuration.java
+++ b/src/main/java/io/shantek/Configuration.java
@@ -12,6 +12,7 @@ public class Configuration {
     private final HorseGuard horseGuard;
     private File dataFile;
     private FileConfiguration dataConfig;
+    private File configFile;
 
     public Configuration(HorseGuard horseGuard) {
         this.horseGuard = horseGuard;
@@ -22,6 +23,12 @@ public class Configuration {
             horseGuard.saveResource("horse_data.yml", false);
         }
         this.dataConfig = YamlConfiguration.loadConfiguration(dataFile);
+
+        this.configFile = new File(horseGuard.getDataFolder(), "config.yml");
+        if (!configFile.exists()) {
+            configFile.getParentFile().mkdirs();
+            horseGuard.saveResource("config.yml", false);
+        }
     }
 
     public void loadHorseData() {

--- a/src/main/java/io/shantek/HorseCommand.java
+++ b/src/main/java/io/shantek/HorseCommand.java
@@ -65,8 +65,13 @@ public class HorseCommand implements CommandExecutor {
     }
 
     private void pluginReload(Player player) {
-        // Reload plugin logic
-        player.sendMessage("Plugin reloaded.");
+        if (!player.hasPermission("shantek.horseguard.reload")) {
+            player.sendMessage(plugin.getMessagePrefix() + "You do not have permission to reload the plugin.");
+            return;
+        }
+
+        plugin.reloadConfig();
+        player.sendMessage(plugin.getMessagePrefix() + "Plugin configuration reloaded.");
     }
 
     private void handleTrust(Player player, String[] args) {

--- a/src/main/java/io/shantek/HorseCommand.java
+++ b/src/main/java/io/shantek/HorseCommand.java
@@ -71,6 +71,8 @@ public class HorseCommand implements CommandExecutor {
         }
 
         plugin.reloadConfig();
+        plugin.loadMessagePrefix();
+        plugin.loadDisabledWorlds();
         player.sendMessage(plugin.getMessagePrefix() + "Plugin configuration reloaded.");
     }
 

--- a/src/main/java/io/shantek/HorseGuard.java
+++ b/src/main/java/io/shantek/HorseGuard.java
@@ -14,7 +14,7 @@ public class HorseGuard extends JavaPlugin {
 
     public HashMap<UUID, UUID> horseOwners = new HashMap<>();
     public HashMap<UUID, HashSet<UUID>> trustedPlayers = new HashMap<>();
-    public Configuration configuration;
+    private Configuration configuration;
     public Metrics metrics;
 
     public String messagePrefix;

--- a/src/main/java/io/shantek/HorseGuard.java
+++ b/src/main/java/io/shantek/HorseGuard.java
@@ -14,10 +14,11 @@ public class HorseGuard extends JavaPlugin {
 
     public HashMap<UUID, UUID> horseOwners = new HashMap<>();
     public HashMap<UUID, HashSet<UUID>> trustedPlayers = new HashMap<>();
-    private Configuration configuration;
+    public Configuration configuration;
     public Metrics metrics;
 
-    private String messagePrefix;
+    public String messagePrefix;
+    public HashSet<String> disabledWorlds = new HashSet<>();
 
     @Override
     public void onEnable() {
@@ -51,6 +52,10 @@ public class HorseGuard extends JavaPlugin {
         this.messagePrefix = ChatColor.translateAlternateColorCodes('&', prefixFromConfig);
     }
 
+    public void loadDisabledWorlds() {
+        this.disabledWorlds = new HashSet<>(getConfig().getStringList("disabled-worlds"));
+    }
+
     // Get the message prefix with ChatColor.RESET appended
     public String getMessagePrefix() {
         return messagePrefix + ChatColor.RESET;
@@ -60,5 +65,6 @@ public class HorseGuard extends JavaPlugin {
     public void reloadHorseGuardConfig() {
         reloadConfig();
         loadMessagePrefix();
+        loadDisabledWorlds();
     }
 }

--- a/src/main/java/io/shantek/Listeners.java
+++ b/src/main/java/io/shantek/Listeners.java
@@ -30,6 +30,8 @@ public class Listeners implements Listener {
 
     @EventHandler
     public void onEntityTame(EntityTameEvent event) {
+        if (helperFunctions.isWorldDisabled(event.getEntity().getWorld()))
+            return;
         if (event.getEntity() instanceof AbstractHorse horse) {
             Player player = (Player) event.getOwner();
             UUID entityUUID = horse.getUniqueId();
@@ -41,6 +43,8 @@ public class Listeners implements Listener {
 
     @EventHandler
     public void onPlayerInteractEntity(PlayerInteractEntityEvent event) {
+        if (helperFunctions.isWorldDisabled(event.getPlayer().getWorld()))
+            return;
         if (event.getRightClicked() instanceof AbstractHorse entity) {
             if (entity instanceof ZombieHorse) {
                 // Ignore interactions with ZombieHorse
@@ -85,6 +89,8 @@ public class Listeners implements Listener {
 
     @EventHandler
     public void onEntityDamage(EntityDamageByEntityEvent event) {
+        if (helperFunctions.isWorldDisabled(event.getEntity().getWorld()))
+            return;
         if (event.getEntity() instanceof AbstractHorse entity && event.getDamager() instanceof Player player) {
 
             if (player.hasPermission("shantek.horseguard.damage")) {

--- a/src/main/java/io/shantek/functions/HelperFunctions.java
+++ b/src/main/java/io/shantek/functions/HelperFunctions.java
@@ -3,6 +3,7 @@ package io.shantek.functions;
 import io.shantek.HorseGuard;
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.World;
 import org.bukkit.entity.AbstractHorse;
 import org.bukkit.entity.Player;
 
@@ -110,6 +111,15 @@ public class HelperFunctions {
         horseGuard.horseOwners.remove(horseUUID);
         horseGuard.trustedPlayers.remove(horseUUID);
         horseGuard.getConfiguration().saveHorseData(); // Save data after modifying
+    }
+
+    public boolean isWorldDisabled(World world) {
+        for (String disabledWorld : horseGuard.disabledWorlds) {
+            if (disabledWorld.equalsIgnoreCase(world.getName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -9,3 +9,7 @@
 
 # Prefix of all messages sent to the player
 message-prefix: "&7[&bHorse&6Guard&7] "
+
+# Worlds where the plugin is disabled
+disabled-worlds:
+  - example_world


### PR DESCRIPTION
- Creates config.yml file for the user if it does not exist
- Implements the reload functionality and adds a permission check for `shantek.horseguard.reload`
- Adds `disabled-worlds` section to config.yml
- Adds `example-world` as a default for `disabled-worlds` to show users how to use 
- Helper function `isWorldDisabled` can be used to determine if a world is a disabled world
- Adds a check to required EventListeners to ensure we are not in a disabled world
- Bump plugin version